### PR TITLE
Add CI and release automation workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,76 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11"]
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        working-directory: voice_summarizer
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -r requirements.dev.txt
+
+      - name: Prepare environment file
+        working-directory: voice_summarizer
+        run: |
+          cp .env.example .env
+          python - <<'PY'
+          from pathlib import Path
+
+          env_path = Path(".env")
+          defaults = {
+              "SECRET_KEY": "dummy-secret-key",
+              "DEBUG": "False",
+              "OPENAI_API_KEY": "dummy-openai-key",
+              "OPENAI_BASE_URL": "",
+              "OPENAI_TRANSCRIBE_MODEL": "dummy-transcribe-model",
+              "OPENAI_SUMMARY_MODEL": "dummy-summary-model",
+          }
+
+          lines = []
+          for line in env_path.read_text().splitlines():
+              if "=" in line:
+                  key, _ = line.split("=", 1)
+                  if key in defaults:
+                      lines.append(f"{key}={defaults[key]}")
+                      continue
+              lines.append(line)
+
+          env_path.write_text("\n".join(lines) + "\n")
+          PY
+
+      - name: Run migrations
+        working-directory: voice_summarizer
+        run: python manage.py migrate --noinput
+
+      - name: Run tests
+        working-directory: voice_summarizer
+        run: |
+          set -o pipefail
+          pytest -q | tee pytest.log
+
+      - name: Upload pytest log on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pytest-log-${{ matrix.python-version }}
+          path: voice_summarizer/pytest.log
+          if-no-files-found: ignore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Build distribution archive
+        run: |
+          zip -r app-dist.zip . \
+            -x 'media/*' '*/media/*' \
+               'db.sqlite3' '*/db.sqlite3' \
+               '__pycache__/*' '*/__pycache__/*' \
+               '.git/*' '.github/workflows/*' \
+               'app-dist.zip'
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: app-dist.zip
+          tag_name: ${{ github.ref_name }}
+          name: Release ${{ github.ref_name }}
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/${{ github.repository }}:${{ github.ref_name }}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# soapify
+# Soapify
+
+This repository contains the `voice_summarizer` Django project for generating transcripts and summaries of uploaded audio.
+
+## Automation
+
+### Continuous integration (`.github/workflows/ci.yml`)
+- Runs on pushes and pull requests that target the `main` branch.
+- Exercises the project against Python 3.10 and 3.11, installs runtime and development dependencies, provisions a dummy `.env`, runs database migrations, and executes the pytest suite (uploading the log if tests fail).
+
+### Release (`.github/workflows/release.yml`)
+- Triggers whenever a Git tag matching `v*` is pushed.
+- Builds a `app-dist.zip` archive without transient media, database, or cache files and publishes it with a GitHub Release.
+- Builds and pushes the Docker image `ghcr.io/<owner>/<repo>:<tag>` from the repository `Dockerfile`, authenticating with the provided `GITHUB_TOKEN`.


### PR DESCRIPTION
## Summary
- add a continuous integration workflow that installs dependencies, prepares a dummy environment file, runs migrations, and executes pytest on Python 3.10 and 3.11
- add a release workflow that zips the project, publishes a GitHub Release, and pushes a Docker image to GHCR when tags matching `v*` are pushed
- document the new automation workflows in the top-level README

## Testing
- not run (workflow changes only)


------
https://chatgpt.com/codex/tasks/task_e_68e68973e2bc83208bce32e7a55d1095