### PR TITLE
Add Dockerfile for Django app and align release pipeline

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+__pycache__
+*.py[cod]
+*.env
+.env*
+venv/
+.venv/
+.idea/
+*.sqlite3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,5 +43,6 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
+          file: ./Dockerfile
           push: true
           tags: ghcr.io/${{ github.repository }}:${{ github.ref_name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.10-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    DJANGO_SETTINGS_MODULE=voice_summarizer.settings \
+    PORT=8000
+
+WORKDIR /app
+
+COPY voice_summarizer/requirements.txt ./requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8000
+
+CMD ["python", "voice_summarizer/manage.py", "runserver", "0.0.0.0:8000"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,16 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 WORKDIR /app
 
-COPY voice_summarizer/requirements.txt ./requirements.txt
+RUN addgroup --system app \
+    && adduser --system --ingroup app app
+
+COPY --chown=app:app voice_summarizer/requirements.txt ./requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY . .
+COPY --chown=app:app . .
+
+USER app
 
 EXPOSE 8000
 
-CMD ["python", "voice_summarizer/manage.py", "runserver", "0.0.0.0:8000"]
+CMD ["/bin/sh", "-c", "exec gunicorn --bind 0.0.0.0:$PORT voice_summarizer.wsgi:application"]

--- a/voice_summarizer/requirements.txt
+++ b/voice_summarizer/requirements.txt
@@ -1,3 +1,4 @@
 django>=5.0,<6.0
 openai>=1.40.0
 python-dotenv>=1.0.1
+gunicorn>=22.0.0


### PR DESCRIPTION
## Summary
- add a root-level Dockerfile to containerize the Django application with Python 3.10 slim
- configure default environment variables, install requirements, and expose port 8000 for the app server
- update the release workflow to build and push using the same Dockerfile

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e68c979c34832082e5f19b211dd36e